### PR TITLE
Potential fix for code scanning alert no. 27: DOM text reinterpreted as HTML

### DIFF
--- a/assets/bootstrap/js/bootstrap.js
+++ b/assets/bootstrap/js/bootstrap.js
@@ -517,7 +517,8 @@ if (typeof jQuery === 'undefined') {
   var clickHandler = function (e) {
     var href
     var $this   = $(this)
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
+    var selector = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, ''); // strip for ie7
+    var $target = $(document).find(selector)
     if (!$target.hasClass('carousel')) return
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')


### PR DESCRIPTION
Potential fix for [https://github.com/masDan13/OpenSID/security/code-scanning/27](https://github.com/masDan13/OpenSID/security/code-scanning/27)

To fix this issue, we need to ensure that the value read from `data-target` or `href` is not interpreted as HTML by jQuery. The best way to do this is to use the `.find()` method on a known, safe context (such as `document`) instead of passing the potentially unsafe string directly to `$()`. This way, the string is only interpreted as a selector, not as HTML, and jQuery will not create new elements or execute scripts. Specifically, we should replace:

```js
var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(...));
```

with:

```js
var selector = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(...);
var $target = $(document).find(selector);
```

This change should be made in the `clickHandler` function in `assets/bootstrap/js/bootstrap.js`. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
